### PR TITLE
Sprint 1 baseline: clean Xcode project scaffold

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,17 @@
+* text=auto
+
+# Better diffs for Swift code
+*.swift diff=swift
+
+# Keep Xcode project files as text (so Git can diff them)
+*.pbxproj text
+
+# Treat images as binary (don’t attempt text diffs)
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.heic binary
+
+# Optional: keep our xcassets treated as text pointers
+*.xcassets text

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 24 August 2025 SpinVal (MusQualDe.tc)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -23,3 +23,19 @@ Next sprint will add camera capture → OCR → display.
 ## Run
 
 Open in Xcode 15+, select iPhone simulator, **Run**.
+
+### Commit standards
+
+When you commit going forward, use these prefixes:
+
+feat: new user‑visible feature
+
+fix: bug fix
+
+chore: tooling/infra (no user impact)
+
+docs: README/docs
+
+refactor: code change no new features/bug fixes
+
+test: adding or fixing tests

--- a/SpinVal.xcodeproj/project.pbxproj
+++ b/SpinVal.xcodeproj/project.pbxproj
@@ -1,0 +1,555 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 77;
+	objects = {
+
+/* Begin PBXContainerItemProxy section */
+		93BD3B632E5B881F0064D527 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 93BD3B4D2E5B881B0064D527 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 93BD3B542E5B881B0064D527;
+			remoteInfo = SpinVal;
+		};
+		93BD3B6D2E5B881F0064D527 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 93BD3B4D2E5B881B0064D527 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 93BD3B542E5B881B0064D527;
+			remoteInfo = SpinVal;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		93BD3B552E5B881B0064D527 /* SpinVal.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SpinVal.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		93BD3B622E5B881F0064D527 /* SpinValTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SpinValTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		93BD3B6C2E5B881F0064D527 /* SpinValUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SpinValUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		93BD3B572E5B881B0064D527 /* SpinVal */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = SpinVal;
+			sourceTree = "<group>";
+		};
+		93BD3B652E5B881F0064D527 /* SpinValTests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = SpinValTests;
+			sourceTree = "<group>";
+		};
+		93BD3B6F2E5B881F0064D527 /* SpinValUITests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = SpinValUITests;
+			sourceTree = "<group>";
+		};
+/* End PBXFileSystemSynchronizedRootGroup section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		93BD3B522E5B881B0064D527 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		93BD3B5F2E5B881F0064D527 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		93BD3B692E5B881F0064D527 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		93BD3B4C2E5B881B0064D527 = {
+			isa = PBXGroup;
+			children = (
+				93BD3B572E5B881B0064D527 /* SpinVal */,
+				93BD3B652E5B881F0064D527 /* SpinValTests */,
+				93BD3B6F2E5B881F0064D527 /* SpinValUITests */,
+				93BD3B562E5B881B0064D527 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		93BD3B562E5B881B0064D527 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				93BD3B552E5B881B0064D527 /* SpinVal.app */,
+				93BD3B622E5B881F0064D527 /* SpinValTests.xctest */,
+				93BD3B6C2E5B881F0064D527 /* SpinValUITests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		93BD3B542E5B881B0064D527 /* SpinVal */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 93BD3B762E5B881F0064D527 /* Build configuration list for PBXNativeTarget "SpinVal" */;
+			buildPhases = (
+				93BD3B512E5B881B0064D527 /* Sources */,
+				93BD3B522E5B881B0064D527 /* Frameworks */,
+				93BD3B532E5B881B0064D527 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				93BD3B572E5B881B0064D527 /* SpinVal */,
+			);
+			name = SpinVal;
+			packageProductDependencies = (
+			);
+			productName = SpinVal;
+			productReference = 93BD3B552E5B881B0064D527 /* SpinVal.app */;
+			productType = "com.apple.product-type.application";
+		};
+		93BD3B612E5B881F0064D527 /* SpinValTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 93BD3B792E5B881F0064D527 /* Build configuration list for PBXNativeTarget "SpinValTests" */;
+			buildPhases = (
+				93BD3B5E2E5B881F0064D527 /* Sources */,
+				93BD3B5F2E5B881F0064D527 /* Frameworks */,
+				93BD3B602E5B881F0064D527 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				93BD3B642E5B881F0064D527 /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				93BD3B652E5B881F0064D527 /* SpinValTests */,
+			);
+			name = SpinValTests;
+			packageProductDependencies = (
+			);
+			productName = SpinValTests;
+			productReference = 93BD3B622E5B881F0064D527 /* SpinValTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		93BD3B6B2E5B881F0064D527 /* SpinValUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 93BD3B7C2E5B881F0064D527 /* Build configuration list for PBXNativeTarget "SpinValUITests" */;
+			buildPhases = (
+				93BD3B682E5B881F0064D527 /* Sources */,
+				93BD3B692E5B881F0064D527 /* Frameworks */,
+				93BD3B6A2E5B881F0064D527 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				93BD3B6E2E5B881F0064D527 /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				93BD3B6F2E5B881F0064D527 /* SpinValUITests */,
+			);
+			name = SpinValUITests;
+			packageProductDependencies = (
+			);
+			productName = SpinValUITests;
+			productReference = 93BD3B6C2E5B881F0064D527 /* SpinValUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		93BD3B4D2E5B881B0064D527 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1640;
+				LastUpgradeCheck = 1640;
+				TargetAttributes = {
+					93BD3B542E5B881B0064D527 = {
+						CreatedOnToolsVersion = 16.4;
+					};
+					93BD3B612E5B881F0064D527 = {
+						CreatedOnToolsVersion = 16.4;
+						TestTargetID = 93BD3B542E5B881B0064D527;
+					};
+					93BD3B6B2E5B881F0064D527 = {
+						CreatedOnToolsVersion = 16.4;
+						TestTargetID = 93BD3B542E5B881B0064D527;
+					};
+				};
+			};
+			buildConfigurationList = 93BD3B502E5B881B0064D527 /* Build configuration list for PBXProject "SpinVal" */;
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 93BD3B4C2E5B881B0064D527;
+			minimizedProjectReferenceProxies = 1;
+			preferredProjectObjectVersion = 77;
+			productRefGroup = 93BD3B562E5B881B0064D527 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				93BD3B542E5B881B0064D527 /* SpinVal */,
+				93BD3B612E5B881F0064D527 /* SpinValTests */,
+				93BD3B6B2E5B881F0064D527 /* SpinValUITests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		93BD3B532E5B881B0064D527 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		93BD3B602E5B881F0064D527 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		93BD3B6A2E5B881F0064D527 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		93BD3B512E5B881B0064D527 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		93BD3B5E2E5B881F0064D527 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		93BD3B682E5B881F0064D527 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		93BD3B642E5B881F0064D527 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 93BD3B542E5B881B0064D527 /* SpinVal */;
+			targetProxy = 93BD3B632E5B881F0064D527 /* PBXContainerItemProxy */;
+		};
+		93BD3B6E2E5B881F0064D527 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 93BD3B542E5B881B0064D527 /* SpinVal */;
+			targetProxy = 93BD3B6D2E5B881F0064D527 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		93BD3B742E5B881F0064D527 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.5;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		93BD3B752E5B881F0064D527 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.5;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		93BD3B772E5B881F0064D527 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.danilo.SpinVal;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		93BD3B782E5B881F0064D527 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.danilo.SpinVal;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		93BD3B7A2E5B881F0064D527 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.5;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.danilo.SpinValTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/SpinVal.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/SpinVal";
+			};
+			name = Debug;
+		};
+		93BD3B7B2E5B881F0064D527 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.5;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.danilo.SpinValTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/SpinVal.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/SpinVal";
+			};
+			name = Release;
+		};
+		93BD3B7D2E5B881F0064D527 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.danilo.SpinValUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = SpinVal;
+			};
+			name = Debug;
+		};
+		93BD3B7E2E5B881F0064D527 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.danilo.SpinValUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = SpinVal;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		93BD3B502E5B881B0064D527 /* Build configuration list for PBXProject "SpinVal" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				93BD3B742E5B881F0064D527 /* Debug */,
+				93BD3B752E5B881F0064D527 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		93BD3B762E5B881F0064D527 /* Build configuration list for PBXNativeTarget "SpinVal" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				93BD3B772E5B881F0064D527 /* Debug */,
+				93BD3B782E5B881F0064D527 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		93BD3B792E5B881F0064D527 /* Build configuration list for PBXNativeTarget "SpinValTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				93BD3B7A2E5B881F0064D527 /* Debug */,
+				93BD3B7B2E5B881F0064D527 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		93BD3B7C2E5B881F0064D527 /* Build configuration list for PBXNativeTarget "SpinValUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				93BD3B7D2E5B881F0064D527 /* Debug */,
+				93BD3B7E2E5B881F0064D527 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 93BD3B4D2E5B881B0064D527 /* Project object */;
+}

--- a/SpinVal.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/SpinVal.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/SpinVal.xcodeproj/xcshareddata/xcschemes/SpinVal.xcscheme
+++ b/SpinVal.xcodeproj/xcshareddata/xcschemes/SpinVal.xcscheme
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1640"
+   version = "2.0">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "93BD3B542E5B881B0064D527"
+               BuildableName = "SpinVal.app"
+               BlueprintName = "SpinVal"
+               ReferencedContainer = "container:SpinVal.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "93BD3B612E5B881F0064D527"
+               BuildableName = "SpinValTests.xctest"
+               BlueprintName = "SpinValTests"
+               ReferencedContainer = "container:SpinVal.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "93BD3B6B2E5B881F0064D527"
+               BuildableName = "SpinValUITests.xctest"
+               BlueprintName = "SpinValUITests"
+               ReferencedContainer = "container:SpinVal.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      askForAppToLaunch = "Yes"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES"
+      launchAutomaticallySubstyle = "2">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "93BD3B542E5B881B0064D527"
+            BuildableName = "SpinVal.app"
+            BlueprintName = "SpinVal"
+            ReferencedContainer = "container:SpinVal.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "93BD3B542E5B881B0064D527"
+            BuildableName = "SpinVal.app"
+            BlueprintName = "SpinVal"
+            ReferencedContainer = "container:SpinVal.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/SpinVal/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/SpinVal/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SpinVal/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/SpinVal/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,35 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "tinted"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SpinVal/Assets.xcassets/Contents.json
+++ b/SpinVal/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SpinVal/ContentView.swift
+++ b/SpinVal/ContentView.swift
@@ -1,0 +1,24 @@
+//
+//  ContentView.swift
+//  SpinVal
+//
+//  Created by Mario Fernandez on 2025-08-24.
+//
+
+import SwiftUI
+
+struct ContentView: View {
+    var body: some View {
+        VStack {
+            Image(systemName: "globe")
+                .imageScale(.large)
+                .foregroundStyle(.tint)
+            Text("Hello, world!")
+        }
+        .padding()
+    }
+}
+
+#Preview {
+    ContentView()
+}

--- a/SpinVal/SpinValApp.swift
+++ b/SpinVal/SpinValApp.swift
@@ -1,0 +1,17 @@
+//
+//  SpinValApp.swift
+//  SpinVal
+//
+//  Created by Mario Fernandez on 2025-08-24.
+//
+
+import SwiftUI
+
+@main
+struct SpinValApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/SpinValTests/SpinValTests.swift
+++ b/SpinValTests/SpinValTests.swift
@@ -1,0 +1,17 @@
+//
+//  SpinValTests.swift
+//  SpinValTests
+//
+//  Created by Mario Fernandez on 2025-08-24.
+//
+
+import Testing
+@testable import SpinVal
+
+struct SpinValTests {
+
+    @Test func example() async throws {
+        // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+    }
+
+}

--- a/SpinValUITests/SpinValUITests.swift
+++ b/SpinValUITests/SpinValUITests.swift
@@ -1,0 +1,41 @@
+//
+//  SpinValUITests.swift
+//  SpinValUITests
+//
+//  Created by Mario Fernandez on 2025-08-24.
+//
+
+import XCTest
+
+final class SpinValUITests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+
+        // In UI tests it is usually best to stop immediately when a failure occurs.
+        continueAfterFailure = false
+
+        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    @MainActor
+    func testExample() throws {
+        // UI tests must launch the application that they test.
+        let app = XCUIApplication()
+        app.launch()
+
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    }
+
+    @MainActor
+    func testLaunchPerformance() throws {
+        // This measures how long it takes to launch your application.
+        measure(metrics: [XCTApplicationLaunchMetric()]) {
+            XCUIApplication().launch()
+        }
+    }
+}

--- a/SpinValUITests/SpinValUITestsLaunchTests.swift
+++ b/SpinValUITests/SpinValUITestsLaunchTests.swift
@@ -1,0 +1,33 @@
+//
+//  SpinValUITestsLaunchTests.swift
+//  SpinValUITests
+//
+//  Created by Mario Fernandez on 2025-08-24.
+//
+
+import XCTest
+
+final class SpinValUITestsLaunchTests: XCTestCase {
+
+    override class var runsForEachTargetApplicationUIConfiguration: Bool {
+        true
+    }
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    @MainActor
+    func testLaunch() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        // Insert steps here to perform after app launch but before taking a screenshot,
+        // such as logging into a test account or navigating somewhere in the app
+
+        let attachment = XCTAttachment(screenshot: app.screenshot())
+        attachment.name = "Launch Screen"
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+}


### PR DESCRIPTION
Closes Sprint 1 — Point 1: Project Setup.

What’s included:
- Added `SpinVal.xcodeproj` and `SwiftUI` scaffold (SpinValApp.swift, ContentView.swift, Assets.xcassets)
- Added SpinValTests and `SpinValUITests` targets
- Restored `.gitignore` for Xcode
- LICENSE and `README.md` moved into project root

Outcome:
- App builds and runs on iOS 18.6 simulator
- Repo structure is clean and ready for Sprint 1 Camera Capture work

Next steps (future PRs):
- Add NSCameraUsageDescription to Info.plist
- Implement Camera Preview (AVFoundation)