### PR TITLE
feat(providers): add ReleaseProvider & PriceProvider protocols

### DIFF
--- a/DataLayer/Providers/PriceProvider.swift
+++ b/DataLayer/Providers/PriceProvider.swift
@@ -5,3 +5,13 @@
 //  Created by Mario Fernandez on 2025-08-31.
 //
 
+import Foundation
+
+/// Contract for anything that can provide a price band for a release.
+protocol PriceProvider {
+    /// Estimate price band primarily via catalog number (MVP path)
+    func priceBand(catalogNumber: String) async throws -> PriceBand
+    
+    /// Optional late: price bu barcode route (keep signature now for clarity; implement late if useful)
+    ///  func priceBand(barcode: String) async throws -> PriceBand
+}

--- a/DataLayer/Providers/ReleaseProvider.swift
+++ b/DataLayer/Providers/ReleaseProvider.swift
@@ -4,4 +4,20 @@
 //
 //  Created by Mario Fernandez on 2025-08-31.
 //
+import Foundation
 
+///Contract for anything that can look up vinyl release metadata.
+///Minimal on purpose for MVP. Implementations (Discogs, MusicBrainz, Mock) will conform to this.
+
+protocol ReleaseProvider {
+    /// Find releases  by catalog nuber (primary MVP path).
+    /// - Paremeter catalogNumber: the lable's catalog code (e.g., ""XL 780", "CBS 65123")
+    /// - Return:  Ranker match with confidence [0.0-1.0].
+    func findRelease(catalogNumber: String) async throws -> [ReleaseMatch]
+    
+    /// Find releases by barcode (UPC/EAN). Some labels put a barcode on the inner label; optional path.
+    func findRelease(barcode: String) async throws -> [ReleaseMatch]
+    
+    /// Fallback text search when we have artist+title but no catalog code.
+    func findRelease(artist: String, title: String) async throws -> [ReleaseMatch]
+}


### PR DESCRIPTION
# Commit adds:

 - Adds `ReleaseProvider` and `PriceProvider` protocol contracts (no implementation).
 - All methods async throws and return ReleaseMatch / PriceBand.

Preps for Discogs/MusicBrainz + pricing adapters in next points.