### PR TITLE
chore(providers): adapter stubs (Sprint 2 – Point 1.6)

### DIFF
--- a/DataLayer/Providers/DiscogsPriceProvider.swift
+++ b/DataLayer/Providers/DiscogsPriceProvider.swift
@@ -1,0 +1,22 @@
+//
+//  DiscogsPriceProvider.swift
+//  SpinVal
+//
+//  Created by Mario Fernandez on 2025-09-04.
+//
+import Foundation
+
+struct DiscogsPriceProvider: PriceProvider {
+    private let client: NetworkClient
+    
+    init(client: NetworkClient) {
+        self.client = client
+    }
+    
+    func priceBand(catalogNumber: String) async throws -> PriceBand {
+        fatalError("not implemented")
+    }
+    
+    // Optional later:
+    // func priceBand(barcode: String) async throw -> PriceBand { fatalError ("not implemented") }
+}

--- a/DataLayer/Providers/DiscogsReleaseProvider.swift
+++ b/DataLayer/Providers/DiscogsReleaseProvider.swift
@@ -1,0 +1,28 @@
+//
+//  DiscogsReleaseProvider.swift
+//  SpinVal
+//
+//  Created by Mario Fernandez on 2025-09-04.
+//
+
+import Foundation
+
+struct DiscogsReleaseProvider: ReleaseProvider {
+    private let client: NetworkClient
+    
+    init(client: NetworkClient){
+        self.client = client
+    }
+    
+    func findRelease(catalogNumber: String) async throws -> [ReleaseMatch] {
+        fatalError("not implemented")
+    }
+    
+    func findRelease(barcode: String) async throws -> [ReleaseMatch] {
+        fatalError("not implemented")
+    }
+    
+    func findRelease(artist: String, title: String) async throws -> [ReleaseMatch] {
+        fatalError("not implemented")
+    }
+}

--- a/DataLayer/Providers/YourAPIPriceProvider.swift
+++ b/DataLayer/Providers/YourAPIPriceProvider.swift
@@ -1,0 +1,14 @@
+//
+//  YourAPIPriceProvider.swift
+//  SpinVal
+//
+//  Created by Mario Fernandez on 2025-09-04.
+//
+
+import Foundation
+
+struct YourAPIPriceProvider: PriceProvider {
+    func priceBand(catalogNumber: String) async throws -> PriceBand {
+        fatalError("not implemented")
+    }
+}


### PR DESCRIPTION
- Adds empty adapters conforming to `ReleaseProvider / PriceProvider`.
 
- Methods stubbed with fatalError("not implemented").

- Preps for Discogs implementation in Sprint 2 Point 2.